### PR TITLE
change unit of txPower from dB to dBm in API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -300,7 +300,7 @@ LoRa.setTxPower(txPower);
 
 LoRa.setTxPower(txPower, outputPin);
 ```
- * `txPower` - TX power in dB, defaults to `17`
+ * `txPower` - TX power in dBm, defaults to `17`
  * `outputPin` - (optional) PA output pin, supported values are `PA_OUTPUT_RFO_PIN` and `PA_OUTPUT_PA_BOOST_PIN`, defaults to `PA_OUTPUT_PA_BOOST_PIN`.
 
 Supported values are `2` to `20` for `PA_OUTPUT_PA_BOOST_PIN`, and `0` to `14` for `PA_OUTPUT_RFO_PIN`.


### PR DESCRIPTION
According to line 148 of the LoRa.cpp file, correct the API tx power documentation.

Source : https://github.com/sandeepmistry/arduino-LoRa/blob/47d7f7793246df9444cc996ceb83567145764cbe/src/LoRa.cpp#L148